### PR TITLE
Updated pagination fixes and removing comments/logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hatchways-fe-blog-ws",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://github.com/sabassegovia/simpleBlog",
+  "homepage": "https://github.com/sabassegovia/52281b",
   "dependencies": {
     "@heroicons/react": "^1.0.6",
     "@testing-library/jest-dom": "^5.16.2",

--- a/src/components/BlogList.jsx
+++ b/src/components/BlogList.jsx
@@ -14,8 +14,8 @@ function BlogList() {
   let lastDisplayOfPage = firstDisplayOfPage + rowsPerPage;
 
   const updateRowsPerPage = (e) => {
-    console.log('code to prevent identical for push purposes');
     setRowsPerPage(Number(e));
+    setCurrentPage(1);
   };
   const updatePage = (e) => {
     setCurrentPage(e);

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,2 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
+
 import "@testing-library/jest-dom";


### PR DESCRIPTION
Updated pagination functionality to go to page one when a new page size is selected, however still stays on the same page if the same page size option is selected.

Console logs have also been deleted.